### PR TITLE
Python 3 check fix

### DIFF
--- a/magento/api.py
+++ b/magento/api.py
@@ -14,7 +14,7 @@ try:
     if sys.version_info < (3, 0):
         from xmlrpclib import ServerProxy
     else:
-        from xmlrpc.client import ServerProxy        
+        from xmlrpc.client import ServerProxy
 except ImportError:
     pass
 else:

--- a/magento/api.py
+++ b/magento/api.py
@@ -11,10 +11,10 @@ from threading import RLock
 
 PROTOCOLS = []
 try:
-    if sys.version_info <= (2,):
+    if sys.version_info < (3, 0):
         from xmlrpclib import ServerProxy
     else:
-        from xmlrpc.client import ServerProxy
+        from xmlrpc.client import ServerProxy        
 except ImportError:
     pass
 else:


### PR DESCRIPTION
Python 2.7.10 evaluates sys.version_info <= (2,) as False
