### PR TITLE
Patch 1

### DIFF
--- a/magento/api.py
+++ b/magento/api.py
@@ -63,7 +63,7 @@ class API(object, metaclass = ClientApiMeta):
     """
     
     """
-    The following line can be removed or left, Python3 ignores metaclass assignement other than class parameter
+    The following line can be removed or left, Python3 ignores metaclass assignment other than class parameter
     """
     ########
     __metaclass__ = ClientApiMeta

--- a/magento/api.py
+++ b/magento/api.py
@@ -57,11 +57,17 @@ class ClientApiMeta(type):
         return Klass
 
 
-class API(object):
+class API(object, metaclass = ClientApiMeta):
     """
     Generic API to connect to magento
     """
+    
+    """
+    The following line can be removed or left, Python3 ignores metaclass assignement other than class parameter
+    """
+    ########
     __metaclass__ = ClientApiMeta
+    ########
     __abstract__ = True
 
     def __init__(self, url, username, password,


### PR DESCRIPTION
The metaclass definition line can be removed or left, Python3 ignores metaclass assignment other than class parameter